### PR TITLE
feat: 新增SpelMin约束注解

### DIFF
--- a/src/main/java/cn/sticki/validator/spel/constrain/SpelMin.java
+++ b/src/main/java/cn/sticki/validator/spel/constrain/SpelMin.java
@@ -1,0 +1,68 @@
+package cn.sticki.validator.spel.constrain;
+
+import cn.sticki.validator.spel.SpelConstraint;
+import cn.sticki.validator.spel.SpelValid;
+import cn.sticki.validator.spel.constraintvalidator.SpelMinValidator;
+import org.intellij.lang.annotations.Language;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * 被标记的元素其值必须大于或等于指定的最小值。{@code null} 元素被认为是有效的。
+ *
+ * @author oddfar
+ * @version 1.0
+ * @since 2024/8/25
+ */
+@Documented
+@Retention(RUNTIME)
+@Target(FIELD)
+@Repeatable(SpelMin.List.class)
+@SpelConstraint(validatedBy = SpelMinValidator.class)
+public @interface SpelMin {
+    /**
+     * 校验失败时的错误消息。
+     */
+    String message() default "必须大于或等于 {value}";
+
+    /**
+     * 约束开启条件，必须为合法的SpEL表达式，计算结果必须为boolean类型。
+     * <p>
+     * 当 表达式为空 或 计算结果为true 时，会对带注解的元素进行校验。
+     * <p>
+     * 默认情况下，开启校验。
+     */
+    @Language("SpEL")
+    String condition() default "";
+
+    /**
+     * 分组条件，必须为合法的SpEL表达式。
+     * <p>
+     * 当分组信息不为空时，只有当 {@link SpelValid#spelGroups()} 中的分组信息与此处的分组信息有交集时，才会对带注解的元素进行校验。
+     * <p>
+     * 其计算结果可以是任何类型，但只有两个计算结果完全相等时，才被认为是相等的。
+     */
+    @Language("SpEL")
+    String[] group() default {};
+
+    /**
+     * @return 指定元素最小值。必须为合法的SpEL表达式，计算结果必须为数字类型。默认值为 0。
+     */
+    @Language("SpEL")
+    String value() default "0";
+
+    @Documented
+    @Target(FIELD)
+    @Retention(RUNTIME)
+    @interface List {
+
+        SpelMin[] value();
+
+    }
+}

--- a/src/main/java/cn/sticki/validator/spel/constraintvalidator/SpelMinValidator.java
+++ b/src/main/java/cn/sticki/validator/spel/constraintvalidator/SpelMinValidator.java
@@ -1,0 +1,44 @@
+package cn.sticki.validator.spel.constraintvalidator;
+
+import cn.sticki.validator.spel.SpelConstraintValidator;
+import cn.sticki.validator.spel.constrain.SpelMin;
+import cn.sticki.validator.spel.parse.SpelParser;
+import cn.sticki.validator.spel.result.FieldValidResult;
+import cn.sticki.validator.spel.util.BigDecimalUtil;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+
+/**
+ * {@link SpelMin} 注解校验器。
+ *
+ * @author oddfar
+ * @version 1.0
+ * @since 2024/8/25
+ */
+public class SpelMinValidator implements SpelConstraintValidator<SpelMin> {
+
+    @Override
+    public FieldValidResult isValid(SpelMin annotation, Object obj, Field field) throws IllegalAccessException {
+        Object fieldValue = field.get(obj);
+        // 元素为null是被允许的
+        if (fieldValue == null) {
+            return FieldValidResult.success();
+        }
+        BigDecimal bigFieldValue = BigDecimalUtil.valueOf(fieldValue);
+
+        // 计算表达式的值
+        Object value = SpelParser.parse(annotation.value(), obj, Object.class);
+        BigDecimal valueBigDecimal = BigDecimalUtil.valueOf(value);
+
+        if (bigFieldValue.compareTo(valueBigDecimal) < 0) {
+            // 构建错误信息
+            String message = annotation.message();
+            message = message.replace("{value}", String.valueOf(value));
+            return new FieldValidResult(false, message);
+        }
+
+        return FieldValidResult.success();
+    }
+
+}

--- a/src/main/java/cn/sticki/validator/spel/util/BigDecimalUtil.java
+++ b/src/main/java/cn/sticki/validator/spel/util/BigDecimalUtil.java
@@ -1,0 +1,28 @@
+package cn.sticki.validator.spel.util;
+
+import java.math.BigDecimal;
+
+/**
+ * BigDecimal工具
+ *
+ * @author oddfar
+ * @since 2024/8/25
+ */
+public class BigDecimalUtil {
+
+    public static BigDecimal valueOf(Object val) {
+        try {
+            if (val instanceof Double) {
+                return BigDecimal.valueOf((Double) val);
+            } else if (val instanceof Float) {
+                return BigDecimal.valueOf((Float) val);
+            } else {
+                return new BigDecimal(String.valueOf(val));
+            }
+        } catch (Exception e) {
+            // 如果转换失败
+            throw new IllegalArgumentException("无法将标记的元素值转换为数值类型");
+        }
+    }
+
+}

--- a/src/test/java/cn/sticki/validator/spel/ConstrainTest.java
+++ b/src/test/java/cn/sticki/validator/spel/ConstrainTest.java
@@ -79,4 +79,13 @@ public class ConstrainTest {
         boolean repeatableTest = ValidateUtil.checkConstraintResult(SpelSizeTestBean.repeatableTestCase());
         Assertions.assertTrue(repeatableTest, "spelSize repeatable test failed");
     }
+
+    @Test
+    void testSpelMin() {
+        boolean paramTest = ValidateUtil.checkConstraintResult(SpelMinTestBean.paramTestCase());
+        Assertions.assertTrue(paramTest, "spelMin param test failed");
+
+        boolean repeatableTest = ValidateUtil.checkConstraintResult(SpelMinTestBean.repeatableTestCase());
+        Assertions.assertTrue(repeatableTest, "spelMin repeatable test failed");
+    }
 }

--- a/src/test/java/cn/sticki/validator/spel/bean/SpelMinTestBean.java
+++ b/src/test/java/cn/sticki/validator/spel/bean/SpelMinTestBean.java
@@ -1,0 +1,233 @@
+package cn.sticki.validator.spel.bean;
+
+import cn.sticki.validator.spel.SpelValid;
+import cn.sticki.validator.spel.VerifyFailedField;
+import cn.sticki.validator.spel.VerifyObject;
+import cn.sticki.validator.spel.constrain.SpelMin;
+import cn.sticki.validator.spel.util.ID;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.validation.constraints.Min;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 功能：SpelMin 测试用例
+ *
+ * @author oddfar
+ * @since 2024/8/25
+ */
+public class SpelMinTestBean {
+
+    /**
+     * 参数测试
+     */
+    @Data
+    @Builder
+    @SpelValid
+    public static class ParamTestBean implements ID {
+
+        private int id;
+
+        private boolean condition;
+
+        private int min;
+
+        // 默认参数
+        @SpelMin
+        private String test;
+
+        // 变量参数
+        @SpelMin(condition = "#this.condition", value = "#this.min", message = "testString")
+        private String testString;
+
+        @SpelMin(condition = "#this.condition", value = "#this.min")
+        private BigDecimal testBigDecimal;
+
+        @SpelMin(condition = "#this.condition", value = "#this.min")
+        private BigInteger testBigInteger;
+
+        @SpelMin(condition = "#this.condition", value = "#this.min")
+        private Byte testByte;
+
+        @SpelMin(condition = "#this.condition", value = "#this.min")
+        private Integer testInt;
+
+        @SpelMin(condition = "#this.condition", value = "#this.min")
+        private Short testShort;
+
+        @SpelMin(condition = "#this.condition", value = "#this.min")
+        @Min(value = 0)
+        private Long testLong;
+
+        @SpelMin(condition = "#this.condition", value = "#this.min")
+        @Min(value = 0)
+        private Double testDouble;
+
+        @SpelMin(condition = "#this.condition", value = "#this.min")
+        private Float testFloat;
+
+    }
+
+    /**
+     * 参数测试
+     */
+    public static List<VerifyObject> paramTestCase() {
+        ArrayList<VerifyObject> result = new ArrayList<>();
+
+        // null
+        result.add(VerifyObject.of(
+                SpelMinTestBean.ParamTestBean.builder().id(1).condition(true).min(1).build(),
+                VerifyFailedField.of()
+        ));
+
+        // 小于最小值
+        result.add(VerifyObject.of(
+                ParamTestBean.builder().id(2).condition(true).min(5)
+                        .test("1")
+                        .testString("2")
+                        .testBigDecimal(new BigDecimal(0))
+                        .testBigInteger(new BigInteger("0"))
+                        .testByte((byte) 0)
+                        .testInt(0)
+                        .testShort((short) 0)
+                        .testLong(0L)
+                        .testDouble((double) (1 / 3))
+                        .testFloat((float) (1 / 3))
+                        .build(),
+                VerifyFailedField.of(
+                        SpelMinTestBean.ParamTestBean::getTestBigDecimal,
+                        SpelMinTestBean.ParamTestBean::getTestBigInteger,
+                        SpelMinTestBean.ParamTestBean::getTestByte,
+                        SpelMinTestBean.ParamTestBean::getTestInt,
+                        SpelMinTestBean.ParamTestBean::getTestShort,
+                        SpelMinTestBean.ParamTestBean::getTestLong,
+                        SpelMinTestBean.ParamTestBean::getTestDouble,
+                        SpelMinTestBean.ParamTestBean::getTestFloat
+                ),
+                VerifyFailedField.of(SpelMinTestBean.ParamTestBean::getTestString, "testString")
+        ));
+
+        // 正常情况
+        result.add(VerifyObject.of(
+                ParamTestBean.builder().id(3).condition(true).min(0)
+                        .test("123")
+                        .testString("123")
+                        .testBigDecimal(new BigDecimal("123.12"))
+                        .testBigInteger(new BigInteger("123123"))
+                        .testByte((byte) 12)
+                        .testInt(12)
+                        .testShort((short) 12)
+                        .testLong(123L)
+                        .testDouble((double) (100 / 3))
+                        .testFloat((float) (100 / 3))
+                        .build()
+        ));
+
+        // message
+        result.add(VerifyObject.of(
+                SpelMinTestBean.ParamTestBean.builder().id(4).condition(true).min(1).testString("2").build(),
+                VerifyFailedField.of(SpelMinTestBean.ParamTestBean::getTestString, "testString")
+        ));
+
+        // condition测试
+        result.add(VerifyObject.of(
+                ParamTestBean.builder().id(5).condition(true).min(0)
+                        .test("123")
+                        .testString("123")
+                        .testBigDecimal(new BigDecimal("123.12"))
+                        .testBigInteger(new BigInteger("123123"))
+                        .testByte((byte) 12)
+                        .testInt(12)
+                        .testShort((short) 12)
+                        .testLong(123L)
+                        .testDouble((double) (100 / 3))
+                        .testFloat((float) (100 / 3))
+                        .build()
+        ));
+        return result;
+    }
+
+    /**
+     * Repeatable 测试
+     */
+    @Data
+    @Builder
+    @SpelValid
+    public static class RepeatableTestBean implements ID {
+
+        private int id;
+
+        private boolean condition1;
+
+        private boolean condition2;
+
+        // 默认参数
+        @SpelMin(condition = "#this.condition1", value = "1", message = "condition1")
+        @SpelMin(condition = "#this.condition2", value = "2", message = "condition2")
+        private Long test;
+
+    }
+
+    /**
+     * Repeatable 测试
+     */
+    public static List<VerifyObject> repeatableTestCase() {
+        ArrayList<VerifyObject> result = new ArrayList<>();
+
+        // condition1
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(1).condition1(true).condition2(false).test(1L).build(),
+                VerifyFailedField.of(SpelMinTestBean.RepeatableTestBean::getTest, "condition1")
+        ));
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(2).condition1(true).condition2(false).test(1L).build()
+        ));
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(3).condition1(true).condition2(false).test(123L).build(),
+                VerifyFailedField.of(SpelMinTestBean.RepeatableTestBean::getTest, "condition1")
+        ));
+
+        // condition2
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(4).condition1(false).condition2(true).test(1L).build(),
+                VerifyFailedField.of(SpelMinTestBean.RepeatableTestBean::getTest, "condition2")
+        ));
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(5).condition1(false).condition2(true).test(12L).build()
+        ));
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(6).condition1(false).condition2(true).test(1234L).build(),
+                VerifyFailedField.of(SpelMinTestBean.RepeatableTestBean::getTest, "condition2")
+        ));
+
+        // condition1 & condition2
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(7).condition1(true).condition2(true).test(1L).build(),
+                VerifyFailedField.of(SpelMinTestBean.RepeatableTestBean::getTest, "condition2")
+        ));
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(8).condition1(true).condition2(true).test(12L).build()
+        ));
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(9).condition1(true).condition2(true).test(123L).build(),
+                VerifyFailedField.of(SpelMinTestBean.RepeatableTestBean::getTest, "condition1")
+        ));
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(10).condition1(true).condition2(true).test(1234L).build(),
+                VerifyFailedField.of(SpelMinTestBean.RepeatableTestBean::getTest, "condition2"),
+                VerifyFailedField.of(SpelMinTestBean.RepeatableTestBean::getTest, "condition1")
+        ));
+        result.add(VerifyObject.of(
+                SpelMinTestBean.RepeatableTestBean.builder().id(11).condition1(true).condition2(true).test(0L).build(),
+                VerifyFailedField.of(SpelMinTestBean.RepeatableTestBean::getTest, "condition1"),
+                VerifyFailedField.of(SpelMinTestBean.RepeatableTestBean::getTest, "condition2")
+        ));
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
有点问题，大佬修复下
```
[INFO ][ParamTestBean][4][] - Start checking object: SpelMinTestBean.ParamTestBean(id=4, condition=true, min=1, test=null, testString=2, testBigDecimal=null, testBigInteger=null, testByte=null, testInt=null, testShort=null, testLong=null, testDouble=null, testFloat=null)
[INFO ][ParamTestBean][4][testString] - Expected exception information: testString
[ERROR][ParamTestBean][4][testString] - Excess field
[INFO ][ParamTestBean][4][] - Verification end, number of failures: 1
[INFO ][ParamTestBean][4][] - ------------------------------------------------------------------------

```